### PR TITLE
CommunicationChannel integration for dynamic OPT scan control

### DIFF
--- a/imswitch/imcontrol/controller/CommunicationChannel.py
+++ b/imswitch/imcontrol/controller/CommunicationChannel.py
@@ -20,6 +20,10 @@ class CommunicationChannel(SignalInterface):
 
     sigAcquisitionStopped = Signal()
 
+    sigLiveStarted = Signal()
+
+    sigLiveStopped = Signal()
+
     sigScriptExecutionFinished = Signal()
 
     sigAdjustFrame = Signal(object)  # (shape)
@@ -45,6 +49,10 @@ class CommunicationChannel(SignalInterface):
     sigMemorySnapAvailable = Signal(
         str, np.ndarray, object, bool
     )  # (name, image, filePath, savedToDisk)
+
+    sigMemoryRecordingAvailable = Signal(
+        str, object, object, bool
+    ) # (name, file, filePath, savedToDisk)
 
     sigRunScan = Signal(bool, bool)  # (recalculateSignals, isNonFinalPartOfSequence)
 

--- a/imswitch/imcontrol/controller/MasterController.py
+++ b/imswitch/imcontrol/controller/MasterController.py
@@ -67,6 +67,8 @@ class MasterController:
 
         self.detectorsManager.sigAcquisitionStarted.connect(cc.sigAcquisitionStarted)
         self.detectorsManager.sigAcquisitionStopped.connect(cc.sigAcquisitionStopped)
+        self.detectorsManager.sigLiveStarted.connect(cc.sigLiveStarted)
+        self.detectorsManager.sigLiveStopped.connect(cc.sigLiveStopped)
         self.detectorsManager.sigDetectorSwitched.connect(cc.sigDetectorSwitched)
         self.detectorsManager.sigImageUpdated.connect(cc.sigUpdateImage)
         self.detectorsManager.sigNewFrame.connect(cc.sigNewFrame)
@@ -76,6 +78,8 @@ class MasterController:
         self.recordingManager.sigRecordingFrameNumUpdated.connect(cc.sigUpdateRecFrameNum)
         self.recordingManager.sigRecordingTimeUpdated.connect(cc.sigUpdateRecTime)
         self.recordingManager.sigMemorySnapAvailable.connect(cc.sigMemorySnapAvailable)
+        self.recordingManager.sigMemoryRecordingAvailable.connect(cc.sigMemoryRecordingAvailable)
+
         self.recordingManager.sigMemoryRecordingAvailable.connect(self.memoryRecordingAvailable)
 
         self.slmManager.sigSLMMaskUpdated.connect(cc.sigSLMMaskUpdated)

--- a/imswitch/imcontrol/controller/controllers/ScanControllerOpt.py
+++ b/imswitch/imcontrol/controller/controllers/ScanControllerOpt.py
@@ -32,16 +32,20 @@ class ScanControllerOpt(ImConWidgetController):
         self.isOptRunning = False
 
         # select detectors
+        # TODO: it would be useful to create a UI section, a combo box for example,
+        # to select the desired detector to extract the data from
         allDetectorNames = self._master.detectorsManager.getAllDeviceNames()
         self.detector = self._master.detectorsManager[allDetectorNames[0]]
 
         # get rotators
+        # TODO: as for detectors, it would be useful to create a UI section, a combo box for example,
+        # to select the desired rotator
         self.getRotators()
         self.__motor_steps = self._master.rotatorsManager[self.__rotators[0]]._motor._steps_per_turn
         self.__logger.debug(f'Your rotators {self.__rotators} with {self.__motor_steps} steps per revolution.')
 
         # Connect widget signals
-        self._widget.scanPar['StartButton'].clicked.connect(self.startOpt)
+        self._widget.scanPar['StartButton'].clicked.connect(self.startOpt) # TODO: if using the communication channel signal, the start button is redundant
         self._widget.scanPar['GetHotPixels'].clicked.connect(self.exec_hot_pixels)
         self._widget.scanPar['GetDark'].clicked.connect(self.exec_dark_field)
         self._widget.scanPar['GetFlat'].clicked.connect(self.exec_flat_field)
@@ -72,12 +76,32 @@ class ScanControllerOpt(ImConWidgetController):
         # and show it on the napari viewer
     
     def handleSnap(self, name, image, filePath, savedToDisk):
+        """ Handles computation over a snapped image. Method is triggered by the `sigMemorySnapAvailable` signal.
+
+        Args:
+            name (`str`): key of the virtual table used to store images in RAM; format is "{filePath}_{channel}"
+            image (`np.ndarray`): captured image snap data;
+            filepath (`str`): path to the file stored on disk;
+            savedToDisk (`bool`): weather the image is saved on disk (True) or not (False)
+        """
+
         snapData = image[self.detector]
-        # TODO: add snap handling
+        # TODO: snapData contains the image currently snapped on the specific detector;
+        # implement how to handle it
 
 
     def displayStack(self, detectorName, image, init, scale, isCurrentDetector):
-        # subsample stack
+        """ Displays captured image (via live view or recording) on napari.
+        Method is triggered via the `sigUpdateImage` signal.
+
+        Args:
+            detectorName (`str`): name of the detector currently capturing
+            image (`np.ndarray`): captured image
+            init (`bool`): weather napari should initialize the layer on which data is displayed (True) or not (False)
+            scale (`List[int]`): the pixel sizes in micrometers; see the `DetectorManager` class for details
+        """
+        # TODO: implement layer update functionality;
+        # the method should only update the layer when a full image is constructed for each slice captured by the detector 
         self._logger.info('displayStack function')
         self._widget.setImage(np.uint16(self.optStack),
                               colormap="gray",
@@ -126,10 +150,7 @@ class ScanControllerOpt(ImConWidgetController):
         self.__rotators = self._master.rotatorsManager.getAllDeviceNames()
 
     def startOpt(self):
-        """ Reset and initiate Opt scan. """
-        self.sigImageReceived.connect(self.displayStack)
-
-        self.
+        """ Sets up the OPT for scanning operation. Method is triggered by the sigAcquisitionStarted signal. """
 
         self._widget.scanPar['StartButton'].setEnabled(False)
         self._widget.scanPar['StopButton'].setEnabled(True)
@@ -149,7 +170,7 @@ class ScanControllerOpt(ImConWidgetController):
         self.scanRecordOpt()
 
     def stopOpt(self):
-        """Stop OPT acquisition and enable buttons
+        """ Stop OPT acquisition and enable buttons. Method is triggered by the sigAcquisitionStopped signal.
         """
         self.isOptRunning = False
         self.sigImageReceived.disconnect()

--- a/imswitch/imcontrol/controller/controllers/ScanControllerOpt.py
+++ b/imswitch/imcontrol/controller/controllers/ScanControllerOpt.py
@@ -192,7 +192,7 @@ class ScanControllerOpt(ImConWidgetController):
         # run OPT
         self.scanRecordOpt()
 
-    def stopOpt(self):
+    def stopOpt(self, live: bool):
         """ Stop OPT acquisition and enable buttons. Method is triggered by the sigAcquisitionStopped signal.
         """
         self.isOptRunning = False

--- a/imswitch/imcontrol/controller/controllers/ScanControllerOpt.py
+++ b/imswitch/imcontrol/controller/controllers/ScanControllerOpt.py
@@ -16,6 +16,7 @@ class ScanControllerOpt(ImConWidgetController):
     """ OPT scan controller.
     """
     sigImageReceived = Signal(str)
+    sigRequestSnap = Signal()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -52,9 +53,30 @@ class ScanControllerOpt(ImConWidgetController):
         if not os.path.exists(self.__opt_dir):
             os.makedirs(self.__opt_dir)
 
+        
+        self.sigRequestSnap.connect(self._commChannel.sigSnapImg)
+
+        self._commChannel.sigRecordingEnded.connect(self.readbackAndDisplay)
+
+        # TODO: read the contents of these signals in the CommunicationChannel class
+        # and implement it in your code
+        self._commChannel.sigAcquisitionStarted.connect(self.startOpt)
+        self._commChannel.sigAcquisitionStopped.connect(self.stopOpt)
+        self._commChannel.sigMemorySnapAvailable.connect(self.handleSnap)
+        self._commChannel.sigUpdateImage.connect(self.displayStack)
+
         # pdb.set_trace()
 
-    def displayStack(self, name):
+    def readbackAndDisplay(self):
+        # open a qt window to readback my file location
+        # and show it on the napari viewer
+    
+    def handleSnap(self, name, image, filePath, savedToDisk):
+        snapData = image[self.detector]
+        # TODO: add snap handling
+
+
+    def displayStack(self, detectorName, image, init, scale, isCurrentDetector):
         # subsample stack
         self._logger.info('displayStack function')
         self._widget.setImage(np.uint16(self.optStack),
@@ -106,6 +128,9 @@ class ScanControllerOpt(ImConWidgetController):
     def startOpt(self):
         """ Reset and initiate Opt scan. """
         self.sigImageReceived.connect(self.displayStack)
+
+        self.
+
         self._widget.scanPar['StartButton'].setEnabled(False)
         self._widget.scanPar['StopButton'].setEnabled(True)
         self._widget.scanPar['StartButton'].setText('Running')

--- a/imswitch/imcontrol/model/managers/DetectorsManager.py
+++ b/imswitch/imcontrol/model/managers/DetectorsManager.py
@@ -12,6 +12,8 @@ class DetectorsManager(MultiManager, SignalInterface):
 
     sigAcquisitionStarted = Signal()
     sigAcquisitionStopped = Signal()
+    sigLiveStarted = Signal()
+    sigLiveStopped = Signal()
     sigDetectorSwitched = Signal(str, str)  # (newDetectorName, oldDetectorName)
     sigImageUpdated = Signal(
         str, np.ndarray, bool, list, bool
@@ -120,6 +122,7 @@ class DetectorsManager(MultiManager, SignalInterface):
         if enableLV:
             sleep(0.3)
             self._thread.start()
+            self.sigLiveStarted.emit()
 
         return handle
 
@@ -150,6 +153,7 @@ class DetectorsManager(MultiManager, SignalInterface):
         if disableLV:
             self._thread.quit()
             self._thread.wait()
+            self.sigLiveStopped.emit()
         if disableAcq:
             self.execOnAll(lambda c: c.stopAcquisition(), condition=lambda c: c.forAcquisition)
             self.sigAcquisitionStopped.emit()


### PR DESCRIPTION
Hi @palec87, I took the liberty to creating this pull request in order to continue the discussion related to the points we talked this morning. I added some information and changes some things in the code in order to provide better clarity on how to proceed with the implementation. I took the liberty of selecting the `add-camera` branch on your fork since it seemed the one with the most recent updates.

### Controlling the scan from the liveview and recording widgets

- You can use the `sigLiveStarted` and `sigLiveStopped` to control the behavior of your OPT during the start / stop phase of the live acquisition; these signals are triggered *AFTER* the live acquisition starts; if you need to prepare the OPT to do something before the start of the live I can add a signal to notify that live acquisition is about to start;
   - more in detail, the live acquisition actually emits two signals: `sigAcquisitionStarted/sigAcquisitionStopped` when the detectors are enabled/disabled for acquiring data (they are emitted *first*); `sigLiveStarted/sigLiveStopped` when the thread polling images from the detectors is started (they are emitted *second*)

### File readback
- I found out a signal which I exposed for your convenience in order to read back a file that has just been finished to be recorded, `sigMemoryRecordingAvailable`; you can use this to immediatly read back a file in your controller.

### Scanning operation

If I correctly understood your workflow, the process of creating your scanned images is to:

- take an image and locally save it in your controller;
- move the rotator of a certain degree;
- once a 360 rotation is complete, patch the image stack and visualize it;

I believe that for running the code to patch the images together you can create a Worker object, move it to a Thread (everything is part of the framework but if you have doubts I'll create stub code for you) and then start the patching algorithm once you collected the full image stack in the background. This will allow to keep ImSwitch running smoothly.

### Adding metadata to your recordings

All controllers provide a method [setSharedAttr](https://github.com/ImSwitch/ImSwitch/blob/b05a431320671c2af16b6db35bed6818d4826d70/imswitch/imcontrol/controller/controllers/PositionerController.py#L89) that allows you to add new attributes which will be then automatically written in the recorded HDF5 / Zarr file (these are the main supported formats). In the link you can find an example implementation in the `PositionerController` class.

All in all I think that the main bulk of the code it's easily implementable with very few changes on the signals side since everything you need seems to be there already (I added the missing pieces for your convenience). Of course we can keep the discussion open so that I can assist you further with the implementation.